### PR TITLE
Add staging reply urls

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   - name: WebSiteUrl
     value: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)
   - name: WebSiteUrlStaging
-    value: https://$(WebSiteName)-staging$(AzureAppServiceWebSiteCustomDomainName)
+    value: https://$(WebSiteName)-staging.azurewebsites.net
   - name: aadAppReplyUrls
     value: $(WebSiteUrl)/, $(WebSiteUrl)/login, $(WebSiteUrlStaging)/, $(WebSiteUrlStaging)/login #CSV list of replay urls
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   - name: WebSiteUrl
     value: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)
   - name: WebSiteUrlStaging
-    value: https://$(WebSiteName)-staging$(AzureAppServiceWebSiteCustomDomainName)/
+    value: https://$(WebSiteName)-staging$(AzureAppServiceWebSiteCustomDomainName)
   - name: aadAppReplyUrls
     value: https://$(WebSiteUrl)/, https://$(WebSiteUrl)/login, https://$(WebSiteUrlStaging)/, https://$(WebSiteUrlStaging)/login #CSV list of replay urls
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   - name: WebSiteUrlStaging
     value: https://$(WebSiteName)-staging$(AzureAppServiceWebSiteCustomDomainName)
   - name: aadAppReplyUrls
-    value: https://$(WebSiteUrl)/, https://$(WebSiteUrl)/login, https://$(WebSiteUrlStaging)/, https://$(WebSiteUrlStaging)/login #CSV list of replay urls
+    value: $(WebSiteUrl)/, $(WebSiteUrl)/login, $(WebSiteUrlStaging)/, $(WebSiteUrlStaging)/login #CSV list of replay urls
 
 
 # GitHub Repo that conatins build templates. Reference https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=vsts#using-other-repositories

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,12 @@ variables:
 
   - name: WebSiteName
     value: $(appName)-$(environmentName) # web site name "$(environmentName)" is set during runtime from GUI. 
-
+  - name: WebSiteUrl
+    value: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)
+  - name: WebSiteUrlStaging
+    value: https://$(WebSiteName)-staging$(AzureAppServiceWebSiteCustomDomainName)/
   - name: aadAppReplyUrls
-    value: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login #CSV list of replay urls
+    value: https://$(WebSiteUrl)/, https://$(WebSiteUrl)/login, https://$(WebSiteUrlStaging)/, https://$(WebSiteUrlStaging)/login #CSV list of replay urls
 
 
 # GitHub Repo that conatins build templates. Reference https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=vsts#using-other-repositories


### PR DESCRIPTION
Added in new reply urls for the staging environment. These are needed to allow us to run the UI automation tests before switching the staging deployment to the actual deployment.